### PR TITLE
Expose global parameters via rundeck integration

### DIFF
--- a/app/services/rundeck_formatter.rb
+++ b/app/services/rundeck_formatter.rb
@@ -13,7 +13,10 @@ class RundeckFormatter
     unless params['rundeckfacts'].empty?
       rdecktags += params['rundeckfacts'].gsub(/\s+/, '').split(',').map { |rdf| "#{rdf}=" + (facts_hash[rdf] || 'undefined') }
     end
-
+    unless params['rundeckglobalparams'].empty?
+      rdecktags += params['rundeckglobalparams'].gsub(/\s+/, '').split(',').map { |rdp| "#{rdp}=" + (params[rdf] || 'undefined') }
+    end
+    
     {name => {'description' => comment, 'hostname' => name, 'nodename' => name,
               'Environment' => environment.name,
               'osArch' => arch.name, 'osFamily' => os.family, 'osName' => os.name,

--- a/app/services/rundeck_formatter.rb
+++ b/app/services/rundeck_formatter.rb
@@ -14,7 +14,7 @@ class RundeckFormatter
       rdecktags += params['rundeckfacts'].gsub(/\s+/, '').split(',').map { |rdf| "#{rdf}=" + (facts_hash[rdf] || 'undefined') }
     end
     unless params['rundeckglobalparams'].empty?
-      rdecktags += params['rundeckglobalparams'].gsub(/\s+/, '').split(',').map { |rdp| "#{rdp}=" + (params[rdf] || 'undefined') }
+      rdecktags += params['rundeckglobalparams'].gsub(/\s+/, '').split(',').map { |rdp| "#{rdp}=" + (params[rdp] || 'undefined') }
     end
     
     {name => {'description' => comment, 'hostname' => name, 'nodename' => name,


### PR DESCRIPTION
I found useful in some situation to expose foreman global parameters as rundeck tags. For this reason, I change the code to include global parameters set in the global parameter rundeckglobalparams in the same way as rundeckfacts.
Hope you'll find this change useful so you include it in the base code.