### PR TITLE
pass url params into formatter

### DIFF
--- a/app/controllers/concerns/foreman_host_rundeck/hosts_controller_extensions.rb
+++ b/app/controllers/concerns/foreman_host_rundeck/hosts_controller_extensions.rb
@@ -11,7 +11,7 @@ module ForemanHostRundeck
       if params[:format] == 'yaml'
         result = {}
         hosts = resource_base.search_for(params[:search], :order => params[:order]).includes(included_associations)
-        hosts.each { |h| result.update(RundeckFormatter.new(h).output) }
+        hosts.each { |h| result.update(RundeckFormatter.new(h, params).output) }
         render :text => result.to_yaml
       else
         index_without_rundeck

--- a/app/services/rundeck_formatter.rb
+++ b/app/services/rundeck_formatter.rb
@@ -1,11 +1,13 @@
 class RundeckFormatter
   attr_reader :host
+  attr_reader :params
 
-  delegate :comment, :name, :arch, :environment, :os, :facts_hash, :puppetclasses_names, :params, :to => :host
+  delegate :comment, :name, :arch, :environment, :os, :facts_hash, :puppetclasses_names, :to => :params, :to => :host
   delegate :logger, :to => :Rails
 
-  def initialize(host)
+  def initialize(host, params)
     @host = host
+    @params = params
   end
 
     def output


### PR DESCRIPTION
Not sure if this is the best solution to the problem but it does work (I am not a ruby rails guy). 

Basically the `rundeckuser` and `rundeckfacts` parameters didn't work because the params field was not the url parameters, but something else not sure what. Passing the url param variable into the formatter fixes the issues.

If this patch is completely off base please point me in the right direction.

I am invoking this plugin like so:

`curl -k -u "user:$pass" -X GET 'https://foreman/hosts/?rundeck=true&format=yaml&rundeckuser=jim&rundeckfacts=domain'`

And getting output like:

```yaml
host.example.com:
  description: ''
  hostname: host.example.com
  nodename: host.example.com
  Environment: production
  osArch: x86_64
  osFamily: Redhat
  osName: CentOS
  osVersion: '6.6'
  tags:
    - domain=example.com
  username: jim
```